### PR TITLE
App duc final

### DIFF
--- a/src/components/CloseFLocationComponent.jsx
+++ b/src/components/CloseFLocationComponent.jsx
@@ -10,7 +10,7 @@ import { View } from "react-native";
 import { Icon, ListItem } from "react-native-elements";
 
 import styles from "../config/styles";
-import { ROUTE_NAMES } from "../constants";
+import { DEFAULT_TIMEOUT, ROUTE_NAMES } from "../constants";
 import { goToFManageSelectScreen, goToOTPScreen } from "../navigations";
 import { showAlertConfirmBox, showToastMessage } from "../utilities";
 import OverlayLoading from "./common/OverlayLoading";
@@ -24,19 +24,22 @@ const CloseFLocationComponent = ({ name, phone }) => {
   );
   const sendOtp = useStoreActions((actions) => actions.UtilModel.sendOtp);
 
-  const [deleteSuccess, setDeleteSuccess] = useState(null);
+  const [deleteSuccess, setDeleteSuccess] = useState(false);
+  // const [otpSendSuccess, setOtpSendSuccess] = useState(null);
   const [loading, setLoading] = useState(false);
 
   const clearLoading = () => setLoading(false);
 
   const sendOtpAction = () => {
     setLoading(true);
-    sendOtp({ phone })
-      .then(() => {
-        goToOTPScreen(navigation, ROUTE_NAMES.FMANAGE_MAIN, phone);
-      })
-      .catch(clearLoading)
-      .finally(clearLoading);
+    setTimeout(() => {
+      sendOtp({ phone })
+        .then(() => {
+          goToOTPScreen(navigation, ROUTE_NAMES.FMANAGE_MAIN, phone);
+        })
+        .catch(clearLoading)
+        .finally(clearLoading);
+    }, DEFAULT_TIMEOUT);
   };
 
   const closeConfirmationAction = () => {
@@ -60,6 +63,14 @@ const CloseFLocationComponent = ({ name, phone }) => {
       }
     }, [route.params]),
   );
+
+  // useEffect(() => {
+  //   if (otpSendSuccess) {
+  //     goToOTPScreen(navigation, ROUTE_NAMES.FMANAGE_MAIN, phone);
+  //   }
+  //   setLoading(false);
+  //   setOtpSendSuccess(null);
+  // }, [otpSendSuccess]);
 
   useEffect(() => {
     if (deleteSuccess) {

--- a/src/components/CloseFLocationComponent.jsx
+++ b/src/components/CloseFLocationComponent.jsx
@@ -10,7 +10,7 @@ import { View } from "react-native";
 import { Icon, ListItem } from "react-native-elements";
 
 import styles from "../config/styles";
-import { DEFAULT_TIMEOUT, ROUTE_NAMES } from "../constants";
+import { ROUTE_NAMES } from "../constants";
 import { goToFManageSelectScreen, goToOTPScreen } from "../navigations";
 import { showAlertConfirmBox, showToastMessage } from "../utilities";
 import OverlayLoading from "./common/OverlayLoading";
@@ -24,22 +24,19 @@ const CloseFLocationComponent = ({ name, phone }) => {
   );
   const sendOtp = useStoreActions((actions) => actions.UtilModel.sendOtp);
 
-  const [deleteSuccess, setDeleteSuccess] = useState(false);
-  // const [otpSendSuccess, setOtpSendSuccess] = useState(null);
+  const [deleteSuccess, setDeleteSuccess] = useState(null);
   const [loading, setLoading] = useState(false);
 
   const clearLoading = () => setLoading(false);
 
   const sendOtpAction = () => {
     setLoading(true);
-    setTimeout(() => {
-      sendOtp({ phone })
-        .then(() => {
-          goToOTPScreen(navigation, ROUTE_NAMES.FMANAGE_MAIN, phone);
-        })
-        .catch(clearLoading)
-        .finally(clearLoading);
-    }, DEFAULT_TIMEOUT);
+    sendOtp({ phone })
+      .then(() => {
+        goToOTPScreen(navigation, ROUTE_NAMES.FMANAGE_MAIN, phone);
+      })
+      .catch(clearLoading)
+      .finally(clearLoading);
   };
 
   const closeConfirmationAction = () => {
@@ -63,14 +60,6 @@ const CloseFLocationComponent = ({ name, phone }) => {
       }
     }, [route.params]),
   );
-
-  // useEffect(() => {
-  //   if (otpSendSuccess) {
-  //     goToOTPScreen(navigation, ROUTE_NAMES.FMANAGE_MAIN, phone);
-  //   }
-  //   setLoading(false);
-  //   setOtpSendSuccess(null);
-  // }, [otpSendSuccess]);
 
   useEffect(() => {
     if (deleteSuccess) {

--- a/src/constants/dictionary.js
+++ b/src/constants/dictionary.js
@@ -11,7 +11,11 @@ export const TOAST_CHANGE_PHONE_NUMBER_SUCCESS_MSG =
 export const TOAST_FISH_DELETE_SUCCESS_MSG = "Cá đã được xóa khỏi hồ";
 export const TOAST_DELETE_LAKE_SUCCESS_MSG = "Xóa hồ bé thành công";
 export const TOAST_WRITE_REVIEW_SUCCESS_MSG = "Đánh giá đăng thành công";
-export const TOAST_CREATE_REPORT_FAIL_MSG = "Gửi thất bại";
+export const TOAST_CREATE_REPORT_FAIL_MSG = "Gửi báo cáo thất bại";
+export const TOAST_ADD_FISH_SPECIES_SUCCESS_MSG = "Thêm cá thành công";
+export const TOAST_EDIT_FISH_SPECIES_SUCCESS_MSG = "Cập nhật cá thành công";
+export const TOAST_UPDATE_FISH_SPECIES_STATUS_SUCCESS_MSG =
+  "Trạng thái của cá đã được thay đổi";
 // END OF RELATED TOAST MESSAGE SECTION
 
 /**
@@ -37,6 +41,10 @@ export const ATTACHMENT_TYPE_NONE_DISPLAY_LABEL = "Không đính kèm";
 export const TODAY_BACKGROUND_COLOR = "#d4d4d4";
 export const SELECTED_DAY_COLOR = "#00ccff";
 export const SELECTED_DAY_TEXT_COLOR = "#000000";
+export const RED_COLOR_SCHEME = "red";
+export const GREEN_COLOR_SCHEME = "red";
+export const IS_ACTIVATE_TEXT = "Đang hoạt động";
+export const IS_DEACTIVATE_TEXT = "Đang ẩn";
 // END OF RANDOM STRING SECTION
 
 /**
@@ -65,6 +73,7 @@ export const FMANAGE_POST_HEADER = "Bài đăng";
 export const ANGLER_WRITE_REVIEW_HEADER = "Đánh giá của bạn";
 export const FMANAGE_CHECK_IN_HISTORY_HEADER = "Lịch sử Check-in";
 export const ANGLER_WRITE_REPORT_HEADER = "Báo cáo vi phạm";
+export const ADMIN_FISH_MANAGEMENT_HEADER = "Quản lý loại cá";
 // END OF RELATED SCREEN HEADER SECTION
 
 /**
@@ -98,7 +107,7 @@ export const ALERT_DELTE_FISH_PROMPT_MSG =
 export const ALERT_EDIT_POST_SUCCESS_MSG = "Chỉnh sửa bài viết thành công";
 export const ALERT_CREATE_POST_SUCCESS_MSG =
   "Gửi thông tin thành công! Bài viết đang được tạo";
-export const ALERT_CREATE_REPORT_SUCCESS = "Gửi Thành công";
+export const ALERT_CREATE_REPORT_SUCCESS = "Gửi báo cáo Thành công";
 // END OF RELATED ALERT SECTION
 
 /**
@@ -159,6 +168,7 @@ export const FORM_FIELD_POST_CONTENT = "content";
 export const FORM_FIELD_RATING = "score";
 export const FORM_FIELD_REVIEW_CONTENT = "description";
 export const FORM_FIELE_REPORT_CONTENT = "content";
+export const FORM_FIELD_ADMIN_FISH_SPECIES_NAME = "name";
 // END OF RELATED FORM FIELD NAME TO REGISTER HOOK FORM SECTION
 
 /**
@@ -179,6 +189,9 @@ export const PREVIOUS_BUTTON_LABEL = "Trước";
 export const NEXT_BUTTON_LABEL = "Sau";
 export const CHANGE_PASSWORD_LABEL = "Đổi mật khẩu";
 export const REPORT_BUTTON_LABEL = "Báo cáo";
+export const SAVE_CHANGES_BUTTON_LABEL = "Lưu thay đổi";
+export const HIDE_THIS_FISH_BUTTON_LABEL = "Ẩn loại cá này";
+export const REVEAL_THIS_FISH_BUTTON_LABEL = "Bỏ ẩn loại cá này";
 // END OF RELATED BUTTON LABELS SECTION
 
 /**
@@ -230,6 +243,7 @@ export const POST_ATTACHMENT_MEDIA_LABEL = "Đường dẫn";
 export const RATING_LABEL = "Điểm số:";
 export const NEW_PHONE_NUMBER_LABEL = "Số điện thoại mới";
 export const REPORT_LABEL = "Hãy miêu tả rõ vi phạm";
+export const ADMIN_FISH_LABEL = "Tên cá";
 // END OF RELATED LABEL SECTIONS
 
 /**
@@ -297,4 +311,5 @@ export const INPUT_REVIEW_CONTENT_PLACEHOLDER = "Đánh giá của bạn về h�
 export const SELECT_DATE_RANGE_PLACEHOLDER = "Theo ngày";
 export const INPUT_NEW_PHONE_NUMBER_PLACEHOLDER = "Nhập số điện thoại mới";
 export const INPUT_REPORT_PLACEHOLDER = "Nhập nội dung vi phạm";
+export const INPUT_ADMIN_FISH_SPECIES_PLACEHOLDER = "Nhập tên cá";
 // END OF RELATED PLACEHOLDER TITLES SECTION

--- a/src/constants/dictionary.js
+++ b/src/constants/dictionary.js
@@ -16,6 +16,12 @@ export const TOAST_ADD_FISH_SPECIES_SUCCESS_MSG = "Thêm cá thành công";
 export const TOAST_EDIT_FISH_SPECIES_SUCCESS_MSG = "Cập nhật cá thành công";
 export const TOAST_UPDATE_FISH_SPECIES_STATUS_SUCCESS_MSG =
   "Trạng thái của cá đã được thay đổi";
+export const TOAST_ADD_FISHING_METHOD_SUCCESS_MSG =
+  "Thêm loại hình câu thành công";
+export const TOAST_EDIT_FISHING_METHOD_SUCCESS_MSG =
+  "Cập nhật loại hình câu thành công";
+export const TOAST_UPDATE_FISHING_METHOD_STATUS_SUCCESS_MSG =
+  "Trạng thái của loại hình câu được thay đổi";
 // END OF RELATED TOAST MESSAGE SECTION
 
 /**
@@ -169,6 +175,7 @@ export const FORM_FIELD_RATING = "score";
 export const FORM_FIELD_REVIEW_CONTENT = "description";
 export const FORM_FIELE_REPORT_CONTENT = "content";
 export const FORM_FIELD_ADMIN_FISH_SPECIES_NAME = "name";
+export const FORM_FIELD_ADMIN_FISHING_METHOD_NAME = "name";
 // END OF RELATED FORM FIELD NAME TO REGISTER HOOK FORM SECTION
 
 /**
@@ -192,6 +199,9 @@ export const REPORT_BUTTON_LABEL = "Báo cáo";
 export const SAVE_CHANGES_BUTTON_LABEL = "Lưu thay đổi";
 export const HIDE_THIS_FISH_BUTTON_LABEL = "Ẩn loại cá này";
 export const REVEAL_THIS_FISH_BUTTON_LABEL = "Bỏ ẩn loại cá này";
+export const HIDE_THIS_METHOD_BUTTON_LABEL = "Ẩn loại cá này";
+export const REVEAL_THIS_METHOD_BUTTON_LABEL = "Bỏ ẩn loại cá này";
+export const ADD_FISHING_METHOD_BUTTON_LABEL = "Thêm loại hình câu";
 // END OF RELATED BUTTON LABELS SECTION
 
 /**
@@ -244,6 +254,7 @@ export const RATING_LABEL = "Điểm số:";
 export const NEW_PHONE_NUMBER_LABEL = "Số điện thoại mới";
 export const REPORT_LABEL = "Hãy miêu tả rõ vi phạm";
 export const ADMIN_FISH_LABEL = "Tên cá";
+export const ADMIN_FISHING_METHOD_LABEL = "Tên loại hình câu";
 // END OF RELATED LABEL SECTIONS
 
 /**

--- a/src/constants/dictionary.js
+++ b/src/constants/dictionary.js
@@ -222,6 +222,7 @@ export const POST_CONTENT_LABEL = "Nội dung";
 export const POST_ATTACHMENT_TYPE_LABEL = "Đính kèm";
 export const POST_ATTACHMENT_MEDIA_LABEL = "Đường dẫn";
 export const RATING_LABEL = "Điểm số:";
+export const NEW_PHONE_NUMBER_LABEL = "Số điện thoại mới";
 // END OF RELATED LABEL SECTIONS
 
 /**
@@ -287,4 +288,5 @@ export const INPUT_ATTACHMENT_MEDIA_PLACEHOLDER =
   "Gắn sao chép liên kết hoặc mã nhúng video";
 export const INPUT_REVIEW_CONTENT_PLACEHOLDER = "Đánh giá của bạn về hồ câu";
 export const SELECT_DATE_RANGE_PLACEHOLDER = "Theo ngày";
+export const INPUT_NEW_PHONE_NUMBER_PLACEHOLDER = "Nhập số điện thoại mới";
 // END OF RELATED PLACEHOLDER TITLES SECTION

--- a/src/constants/dictionary.js
+++ b/src/constants/dictionary.js
@@ -11,6 +11,7 @@ export const TOAST_CHANGE_PHONE_NUMBER_SUCCESS_MSG =
 export const TOAST_FISH_DELETE_SUCCESS_MSG = "Cá đã được xóa khỏi hồ";
 export const TOAST_DELETE_LAKE_SUCCESS_MSG = "Xóa hồ bé thành công";
 export const TOAST_WRITE_REVIEW_SUCCESS_MSG = "Đánh giá đăng thành công";
+export const TOAST_CREATE_REPORT_FAIL_MSG = "Gửi thất bại";
 // END OF RELATED TOAST MESSAGE SECTION
 
 /**
@@ -63,6 +64,7 @@ export const ANGLER_RESET_PASSWORD_HEADER = "Thay đổi mật khẩu";
 export const FMANAGE_POST_HEADER = "Bài đăng";
 export const ANGLER_WRITE_REVIEW_HEADER = "Đánh giá của bạn";
 export const FMANAGE_CHECK_IN_HISTORY_HEADER = "Lịch sử Check-in";
+export const ANGLER_WRITE_REPORT_HEADER = "Báo cáo vi phạm";
 // END OF RELATED SCREEN HEADER SECTION
 
 /**
@@ -96,6 +98,7 @@ export const ALERT_DELTE_FISH_PROMPT_MSG =
 export const ALERT_EDIT_POST_SUCCESS_MSG = "Chỉnh sửa bài viết thành công";
 export const ALERT_CREATE_POST_SUCCESS_MSG =
   "Gửi thông tin thành công! Bài viết đang được tạo";
+export const ALERT_CREATE_REPORT_SUCCESS = "Gửi Thành công";
 // END OF RELATED ALERT SECTION
 
 /**
@@ -155,6 +158,7 @@ export const FORM_FIELD_POST_TYPE = "postType";
 export const FORM_FIELD_POST_CONTENT = "content";
 export const FORM_FIELD_RATING = "score";
 export const FORM_FIELD_REVIEW_CONTENT = "description";
+export const FORM_FIELE_REPORT_CONTENT = "content";
 // END OF RELATED FORM FIELD NAME TO REGISTER HOOK FORM SECTION
 
 /**
@@ -174,6 +178,7 @@ export const POST_BUTTON_LABEL = "Đăng";
 export const PREVIOUS_BUTTON_LABEL = "Trước";
 export const NEXT_BUTTON_LABEL = "Sau";
 export const CHANGE_PASSWORD_LABEL = "Đổi mật khẩu";
+export const REPORT_BUTTON_LABEL = "Báo cáo";
 // END OF RELATED BUTTON LABELS SECTION
 
 /**
@@ -224,6 +229,7 @@ export const POST_ATTACHMENT_TYPE_LABEL = "Đính kèm";
 export const POST_ATTACHMENT_MEDIA_LABEL = "Đường dẫn";
 export const RATING_LABEL = "Điểm số:";
 export const NEW_PHONE_NUMBER_LABEL = "Số điện thoại mới";
+export const REPORT_LABEL = "Hãy miêu tả rõ vi phạm";
 // END OF RELATED LABEL SECTIONS
 
 /**
@@ -290,4 +296,5 @@ export const INPUT_ATTACHMENT_MEDIA_PLACEHOLDER =
 export const INPUT_REVIEW_CONTENT_PLACEHOLDER = "Đánh giá của bạn về hồ câu";
 export const SELECT_DATE_RANGE_PLACEHOLDER = "Theo ngày";
 export const INPUT_NEW_PHONE_NUMBER_PLACEHOLDER = "Nhập số điện thoại mới";
+export const INPUT_REPORT_PLACEHOLDER = "Nhập nội dung vi phạm";
 // END OF RELATED PLACEHOLDER TITLES SECTION

--- a/src/constants/validationSchema.js
+++ b/src/constants/validationSchema.js
@@ -380,3 +380,7 @@ export const WRITE_REVIEW_FORM = yup.object().shape({
   score: yup.number().moreThan(0, "Số sao không được bỏ trống"),
   description: yup.string().required("Đánh giá không được bỏ trống"),
 });
+
+export const WRITE_REPORT_FORM = yup.object().shape({
+  content: yup.string().required("Nội dung báo cáo không thể bỏ trống"),
+});

--- a/src/constants/validationSchema.js
+++ b/src/constants/validationSchema.js
@@ -340,6 +340,7 @@ export const LOGIN_FORM = yup.object().shape({
   password: yup
     .string()
     .required("Mật khẩu không được bỏ trống")
+    .min(8, "Mật khẩu phải chứa ít nhất 8 ký tự")
     .label("Password"),
 });
 

--- a/src/screens/AdminFishEditScreen.js
+++ b/src/screens/AdminFishEditScreen.js
@@ -13,7 +13,7 @@ import { Dimensions } from "react-native";
 import InputComponent from "../components/common/InputComponent";
 import MultiImageSection from "../components/common/MultiImageSection";
 import HeaderTab from "../components/HeaderTab";
-import { ROUTE_NAMES, SCHEMA } from "../constants";
+import { DICTIONARY, ROUTE_NAMES, SCHEMA } from "../constants";
 import { showToastMessage } from "../utilities";
 
 const OFFSET_BOTTOM = 85;
@@ -49,11 +49,11 @@ const AdminFishEditScreen = () => {
       .then(() => {
         if (!fishId) {
           getAdminFishList();
-          showToastMessage("Thêm cá thành công");
+          showToastMessage(DICTIONARY.TOAST_ADD_FISH_SPECIES_SUCCESS_MSG);
           navigation.pop(1);
         } else {
           setIsLoading(false);
-          showToastMessage("Cập nhật cá thành công");
+          showToastMessage(DICTIONARY.TOAST_EDIT_FISH_SPECIES_SUCCESS_MSG);
         }
       })
       .catch(handleError);
@@ -65,7 +65,9 @@ const AdminFishEditScreen = () => {
       .then(() => {
         setIsLoading(false);
         setIsActive(!isActive);
-        showToastMessage("Trạng thái của cá đã được thay đổi");
+        showToastMessage(
+          DICTIONARY.TOAST_UPDATE_FISH_SPECIES_STATUS_SUCCESS_MSG,
+        );
       })
       .catch(handleError);
   };
@@ -75,8 +77,8 @@ const AdminFishEditScreen = () => {
     if (id) {
       const { name, image, active } = route.params;
       setFishId(id);
-      setValue("name", name);
-      setValue("imageArray", [{ id: 1, base64: image }]);
+      setValue(DICTIONARY.FORM_FIELD_ADMIN_FISH_SPECIES_NAME, name);
+      setValue(DICTIONARY.FORM_FIELD_IMAGE_ARRAY, [{ id: 1, base64: image }]);
       setIsActive(active);
     }
   }, []);
@@ -85,7 +87,7 @@ const AdminFishEditScreen = () => {
     // useCallback will listen to route.param
     useCallback(() => {
       if (route.params?.base64Array && route.params.base64Array.length) {
-        setValue("imageArray", route.params?.base64Array);
+        setValue(DICTIONARY.FORM_FIELD_IMAGE_ARRAY, route.params?.base64Array);
         navigation.setParams({ base64Array: [] });
       }
     }, [route.params]),
@@ -93,7 +95,7 @@ const AdminFishEditScreen = () => {
 
   return (
     <>
-      <HeaderTab name="Quản lý loại cá" />
+      <HeaderTab name={DICTIONARY.ADMIN_FISH_MANAGEMENT_HEADER} />
       <Box height={CUSTOM_SCREEN_HEIGHT}>
         <FormProvider {...methods}>
           <VStack
@@ -108,15 +110,15 @@ const AdminFishEditScreen = () => {
             <MultiImageSection
               containerStyle={{ width: "90%" }}
               formRoute={ROUTE_NAMES.ADMIN_FISH_MANAGEMENT_EDIT}
-              controllerName="imageArray"
+              controllerName={DICTIONARY.FORM_FIELD_IMAGE_ARRAY}
             />
             <InputComponent
               myStyles={{ width: "90%" }}
-              label="Tên cá"
+              label={DICTIONARY.ADMIN_FISH_LABEL}
               isTitle
               hasAsterisk
-              placeholder="Nhập tên cá"
-              controllerName="name"
+              placeholder={DICTIONARY.INPUT_ADMIN_FISH_SPECIES_PLACEHOLDER}
+              controllerName={DICTIONARY.FORM_FIELD_ADMIN_FISH_SPECIES_NAME}
             />
 
             {fishId && (
@@ -128,7 +130,9 @@ const AdminFishEditScreen = () => {
                   fontSize="md"
                   color={isActive ? "success.500" : "danger.500"}
                 >
-                  {isActive ? "Đang hoạt động" : "Đang ẩn"}
+                  {isActive
+                    ? DICTIONARY.IS_ACTIVATE_TEXT
+                    : DICTIONARY.IS_DEACTIVATE_TEXT}
                 </Text>
               </Box>
             )}
@@ -141,19 +145,27 @@ const AdminFishEditScreen = () => {
             isLoadingText="Đang xử lý"
             onPress={handleSubmit(onSubmit)}
           >
-            {fishId ? "Lưu thay đổi" : "Thêm loại cá"}
+            {fishId
+              ? DICTIONARY.SAVE_CHANGES_BUTTON_LABEL
+              : DICTIONARY.ADD_FISH_BUTTON_LABEL}
           </Button>
           {fishId && (
             <Button
               w="80%"
-              colorScheme={isActive ? "red" : "green"}
+              colorScheme={
+                isActive
+                  ? DICTIONARY.RED_COLOR_SCHEME
+                  : DICTIONARY.GREEN_COLOR_SCHEME
+              }
               alignSelf="center"
               marginTop={2}
               isLoading={isLoading}
-              isLoadingText="Đang xử lý"
+              isLoadingText={DICTIONARY.PROCESSING_BUTTON_LABEL}
               onPress={handleUpdateStatus}
             >
-              {isActive ? "Ẩn loại cá này" : "Bỏ ẩn loại cá này"}
+              {isActive
+                ? DICTIONARY.HIDE_THIS_FISH_BUTTON_LABEL
+                : DICTIONARY.REVEAL_THIS_FISH_BUTTON_LABEL}
             </Button>
           )}
         </FormProvider>

--- a/src/screens/AdminFishEditScreen.js
+++ b/src/screens/AdminFishEditScreen.js
@@ -142,7 +142,7 @@ const AdminFishEditScreen = () => {
             w="80%"
             alignSelf="center"
             isLoading={isLoading}
-            isLoadingText="Đang xử lý"
+            isLoadingText={DICTIONARY.PROCESSING_BUTTON_LABEL}
             onPress={handleSubmit(onSubmit)}
           >
             {fishId

--- a/src/screens/AdminFishingMethodEditScreen.js
+++ b/src/screens/AdminFishingMethodEditScreen.js
@@ -8,11 +8,10 @@ import { Dimensions } from "react-native";
 
 import InputComponent from "../components/common/InputComponent";
 import HeaderTab from "../components/HeaderTab";
-import { SCHEMA } from "../constants";
+import { DICTIONARY, SCHEMA } from "../constants";
 import { showToastMessage } from "../utilities";
 
 const OFFSET_BOTTOM = 85;
-// Get window height without status bar height
 const CUSTOM_SCREEN_HEIGHT = Dimensions.get("window").height - OFFSET_BOTTOM;
 
 const AdminFishingMethodEditScreen = () => {
@@ -43,11 +42,11 @@ const AdminFishingMethodEditScreen = () => {
       .then(() => {
         if (!methodId) {
           getAdminFishingMethodList();
-          showToastMessage("Thêm loại hình câu thành công");
+          showToastMessage(DICTIONARY.TOAST_ADD_FISHING_METHOD_SUCCESS_MSG);
           navigation.pop(1);
         } else {
           setIsLoading(false);
-          showToastMessage("Cập nhật loại hình câu thành công");
+          showToastMessage(DICTIONARY.TOAST_EDIT_FISHING_METHOD_SUCCESS_MSG);
         }
       })
       .catch(handleError);
@@ -59,7 +58,9 @@ const AdminFishingMethodEditScreen = () => {
       .then(() => {
         setIsLoading(false);
         setIsActive(!isActive);
-        showToastMessage("Trạng thái của loại hình câu đã được thay đổi");
+        showToastMessage(
+          DICTIONARY.TOAST_UPDATE_FISHING_METHOD_STATUS_SUCCESS_MSG,
+        );
       })
       .catch(handleError);
   };
@@ -68,7 +69,7 @@ const AdminFishingMethodEditScreen = () => {
     const { id, name, active } = route.params;
     if (id) {
       setMethodId(id);
-      setValue("name", name);
+      setValue(DICTIONARY.FORM_FIELD_ADMIN_FISHING_METHOD_NAME, name);
       setIsActive(active);
     }
   }, []);
@@ -79,13 +80,12 @@ const AdminFishingMethodEditScreen = () => {
       <Box height={CUSTOM_SCREEN_HEIGHT}>
         <FormProvider {...methods}>
           <Center flex={1} w="100%" mt={10} justifyContent="flex-start">
-            {/* Fishing method name input field */}
             <InputComponent
               myStyles={{ width: "90%" }}
-              label="Tên loại hình câu"
+              label={DICTIONARY.ADMIN_FISHING_METHOD_LABEL}
               isTitle
               hasAsterisk
-              controllerName="name"
+              controllerName={DICTIONARY.FORM_FIELD_ADMIN_FISHING_METHOD_NAME}
             />
             {methodId && (
               <Box
@@ -101,7 +101,9 @@ const AdminFishingMethodEditScreen = () => {
                   fontSize="md"
                   color={isActive ? "success.500" : "danger.500"}
                 >
-                  {isActive ? "Đang hoạt động" : "Đang ẩn"}
+                  {isActive
+                    ? DICTIONARY.IS_ACTIVATE_TEXT
+                    : DICTIONARY.IS_DEACTIVATE_TEXT}
                 </Text>
               </Box>
             )}
@@ -111,21 +113,29 @@ const AdminFishingMethodEditScreen = () => {
             alignSelf="center"
             onPress={handleSubmit(onSubmit)}
             isLoading={isLoading}
-            isLoadingText="Đang xử lý"
+            isLoadingText={DICTIONARY.PROCESSING_BUTTON_LABEL}
           >
-            {methodId ? "Lưu thay đổi" : "Thêm loại hình câu"}
+            {methodId
+              ? DICTIONARY.SAVE_CHANGES_BUTTON_LABEL
+              : DICTIONARY.ADD_FISHING_METHOD_BUTTON_LABEL}
           </Button>
           {methodId && (
             <Button
               w="80%"
-              colorScheme={isActive ? "red" : "green"}
+              colorScheme={
+                isActive
+                  ? DICTIONARY.RED_COLOR_SCHEME
+                  : DICTIONARY.GREEN_COLOR_SCHEME
+              }
               alignSelf="center"
               marginTop={2}
               onPress={handleUpdateStatus}
               isLoading={isLoading}
-              isLoadingText="Đang xử lý"
+              isLoadingText={DICTIONARY.PROCESSING_BUTTON_LABEL}
             >
-              {isActive ? "Ẩn loại hình câu này" : "Bỏ ẩn loại hình câu này"}
+              {isActive
+                ? DICTIONARY.HIDE_THIS_METHOD_BUTTON_LABEL
+                : DICTIONARY.REVEAL_THIS_METHOD_BUTTON_LABEL}
             </Button>
           )}
         </FormProvider>

--- a/src/screens/AnglerCatchReportDetailScreen.js
+++ b/src/screens/AnglerCatchReportDetailScreen.js
@@ -2,10 +2,10 @@ import { useNavigation, useRoute } from "@react-navigation/native";
 import { useStoreActions, useStoreState } from "easy-peasy";
 import { Box, Divider, ScrollView, Text, VStack } from "native-base";
 import React, { useEffect, useState } from "react";
-import { ActivityIndicator } from "react-native";
 import Swiper from "react-native-swiper";
 
 import AvatarCard from "../components/AvatarCard";
+import OverlayLoading from "../components/common/OverlayLoading";
 import FishInformationCard from "../components/FishInformationCard";
 import HeaderTab from "../components/HeaderTab";
 import ImageResizeMode from "../components/ImageResizeMode";
@@ -46,12 +46,7 @@ const AnglerCatchReportDetailScreen = () => {
 
   const { avatar } = catchDetails;
 
-  if (isLoading)
-    return (
-      <Box flex={1} justifyContent="center" alignItems="center">
-        <ActivityIndicator size="large" color="blue" />
-      </Box>
-    );
+  if (isLoading) return <OverlayLoading coverScreen />;
 
   if (!catchDetails.id) {
     return (

--- a/src/screens/AnglerChangePhoneNumberScreen.js
+++ b/src/screens/AnglerChangePhoneNumberScreen.js
@@ -99,11 +99,11 @@ const ChangePhoneNumberScreen = () => {
           w={{ base: "70%", md: "50%", lg: "30%" }}
         >
           <InputComponent
-            label={DICTIONARY.PHONE_NUMBER_LABEL}
+            label={DICTIONARY.NEW_PHONE_NUMBER_LABEL}
             useNumPad
             isTitle
             hasAsterisk
-            placeholder={DICTIONARY.INPUT_PHONE_NUMBER_PLACEHOLDER}
+            placeholder={DICTIONARY.INPUT_NEW_PHONE_NUMBER_PLACEHOLDER}
             controllerName={DICTIONARY.FORM_FIELD_ANGLER_PHONE}
           />
           <PasswordInput

--- a/src/screens/FManageEditPendingProfileScreen.js
+++ b/src/screens/FManageEditPendingProfileScreen.js
@@ -106,7 +106,7 @@ const FManageEditPendingProfileScreen = () => {
     const handleGoBack = () => goBack(navigation);
     showAlertAbsoluteBox(
       DICTIONARY.ALERT_TITLE,
-      DICTIONARY.ALERT_EDIT_PROFILE_SUCCESS_MSG,
+      DICTIONARY.ALERT_EDIT_LOCATION_SUCCESS_MSG,
       handleGoBack,
     );
   };

--- a/src/screens/FManageVerifyCatchReportDetailScreen.js
+++ b/src/screens/FManageVerifyCatchReportDetailScreen.js
@@ -12,10 +12,10 @@ import {
   VStack,
 } from "native-base";
 import React, { useEffect, useState } from "react";
-import { ActivityIndicator } from "react-native";
 import Swiper from "react-native-swiper";
 
 import AvatarCard from "../components/AvatarCard";
+import OverlayLoading from "../components/common/OverlayLoading";
 import FishInformationCard from "../components/FishInformationCard";
 import HeaderTab from "../components/HeaderTab";
 import ImageResizeMode from "../components/ImageResizeMode";
@@ -89,12 +89,7 @@ const AnglerCatchReportDetailScreen = () => {
 
   const { avatar } = catchDetails;
 
-  if (isLoading)
-    return (
-      <Box flex={1} justifyContent="center" alignItems="center">
-        <ActivityIndicator size="large" color="blue" />
-      </Box>
-    );
+  if (isLoading) return <OverlayLoading coverScreen />;
 
   if (!catchDetails.id) {
     return (

--- a/src/screens/FManageVerifyCatchReportScreen.js
+++ b/src/screens/FManageVerifyCatchReportScreen.js
@@ -2,9 +2,10 @@ import { useNavigation } from "@react-navigation/native";
 import { useStoreActions, useStoreState } from "easy-peasy";
 import { Box, Button, FlatList, HStack, Text, VStack } from "native-base";
 import PropTypes from "prop-types";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 
 import AvatarCard from "../components/AvatarCard";
+import SmallScreenLoadingIndicator from "../components/common/SmallScreenLoadingIndicator";
 import HeaderTab from "../components/HeaderTab";
 import { DEFAULT_TIMEOUT, KEY_EXTRACTOR } from "../constants";
 import { goToCatchReportVerifyDetailScreen } from "../navigations";
@@ -109,9 +110,30 @@ UnresolvedCatchReportComponent.propTypes = {
 };
 
 const VerifyCatchReportScreen = () => {
-  const unresolvedCatchReportList = useStoreState(
-    (states) => states.FManageModel.unresolvedCatchReportList,
-  );
+  const pageNo = useRef(1);
+  const needRefresh = useRef(true);
+  const [isLoading, setIsLoading] = useState(true);
+  const { unresolvedCatchReportList, unresolvedCatchReportTotalPage } =
+    useStoreState((states) => states.FManageModel);
+  const { getUnresolvedCatchReportList, clearUnresolvedCatchReportList } =
+    useStoreActions((actions) => actions.FManageModel);
+
+  /**
+   * Start loading to run getCatchReport function
+   * @param {Boolean} shouldRefresh flag to set needRefresh variable to true
+   */
+  const startLoading = (shouldRefresh = true) => {
+    if (shouldRefresh) needRefresh.current = true;
+    setIsLoading(true);
+  };
+
+  /**
+   * Stop loading when get is finished
+   */
+  const stopLoading = () => {
+    if (needRefresh.current) needRefresh.current = false;
+    setIsLoading(false);
+  };
 
   const memoizedStyle = useMemo(
     () =>
@@ -121,25 +143,54 @@ const VerifyCatchReportScreen = () => {
     [unresolvedCatchReportList && unresolvedCatchReportList.length > 0],
   );
 
-  const getUnresolvedCatchReportList = useStoreActions(
-    (actions) => actions.FManageModel.getUnresolvedCatchReportList,
-  );
-
-  const onEndReached = () => {
-    getUnresolvedCatchReportList({ status: "APPEND" });
+  /**
+   * Handle go to next page to get list item
+   */
+  const handleLoadMore = () => {
+    if (pageNo.current < unresolvedCatchReportTotalPage) {
+      pageNo.current += 1;
+      startLoading(false);
+    }
   };
 
-  useEffect(() => {
-    getUnresolvedCatchReportList({ status: "OVERWRITE" });
-  }, []);
+  /**
+   * Handle get the list starting from page 1
+   */
+  const handleOnRefresh = () => {
+    pageNo.current = 1;
+    startLoading();
+  };
 
-  const renderEmtpy = () => (
-    <Text color="gray.500" alignSelf="center">
-      Chưa có báo cá nào cần duyệt
-    </Text>
-  );
+  const renderEmtpy = () =>
+    !isLoading && (
+      <Text color="gray.500" alignSelf="center">
+        Chưa có báo cá nào cần duyệt
+      </Text>
+    );
+
+  const renderFooter = () =>
+    isLoading &&
+    !needRefresh.current && (
+      <SmallScreenLoadingIndicator containerStyle={{ marginVertical: 12 }} />
+    );
 
   const renderItem = ({ item }) => <UnresolvedCatchReportComponent {...item} />;
+
+  const memoizedRender = useMemo(() => renderItem, [unresolvedCatchReportList]);
+
+  useEffect(() => {
+    return () => {
+      clearUnresolvedCatchReportList();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isLoading) {
+      getUnresolvedCatchReportList({ pageNo: pageNo.current }).finally(
+        stopLoading,
+      );
+    }
+  }, [isLoading]);
 
   return (
     <Box>
@@ -150,10 +201,14 @@ const VerifyCatchReportScreen = () => {
           height="90%"
           contentContainerStyle={memoizedStyle}
           data={unresolvedCatchReportList}
-          renderItem={renderItem}
+          renderItem={memoizedRender}
           ListEmptyComponent={renderEmtpy}
+          ListFooterComponent={renderFooter}
           keyExtractor={KEY_EXTRACTOR}
-          onEndReached={onEndReached}
+          onEndReached={handleLoadMore}
+          onEndReachedThreshold={0.2}
+          onRefresh={handleOnRefresh}
+          refreshing={isLoading && needRefresh.current}
         />
       </Box>
     </Box>

--- a/src/screens/FManageVerifyCatchReportScreen.js
+++ b/src/screens/FManageVerifyCatchReportScreen.js
@@ -111,7 +111,7 @@ UnresolvedCatchReportComponent.propTypes = {
 
 const VerifyCatchReportScreen = () => {
   const pageNo = useRef(1);
-  const needRefresh = useRef(true);
+  const needRefresh = useRef(false);
   const [isLoading, setIsLoading] = useState(true);
   const { unresolvedCatchReportList, unresolvedCatchReportTotalPage } =
     useStoreState((states) => states.FManageModel);

--- a/src/screens/WriteReportScreen.js
+++ b/src/screens/WriteReportScreen.js
@@ -22,6 +22,7 @@ const CUSTOM_SCREEN_HEIGHT = Dimensions.get("window").height - OFF_SET;
 const ReportScreen = () => {
   const route = useRoute();
   const navigation = useNavigation();
+  const [isLoading, setIsLoading] = useState(false);
   const reportParam = useRef({});
   const methods = useForm({
     mode: "onSubmit",
@@ -39,7 +40,12 @@ const ReportScreen = () => {
   };
 
   const onSubmit = (data) => {
-    sendReport({ reportDtoIn: data.content, ...reportParam, setSendStatus });
+    setIsLoading(true);
+    sendReport({
+      reportDtoIn: data.content,
+      ...reportParam.current,
+      setSendStatus,
+    });
   };
 
   useEffect(() => {
@@ -52,6 +58,7 @@ const ReportScreen = () => {
 
   useEffect(() => {
     if (sendStatus === true) {
+      setIsLoading(false);
       showAlertAbsoluteBox(
         DICTIONARY.ALERT_TITLE,
         DICTIONARY.ALERT_CREATE_REPORT_SUCCESS,
@@ -59,6 +66,7 @@ const ReportScreen = () => {
       );
     }
     if (sendStatus === false) {
+      setIsLoading(false);
       showToastMessage(DICTIONARY.TOAST_CREATE_REPORT_FAIL_MSG);
     }
     setSendStatus(null);
@@ -86,6 +94,7 @@ const ReportScreen = () => {
             controllerName={DICTIONARY.FORM_FIELE_REPORT_CONTENT}
           />
           <Button
+            loading={isLoading}
             title={DICTIONARY.REPORT_BUTTON_LABEL}
             containerStyle={{ width: "90%" }}
             onPress={handleSubmit(onSubmit)}

--- a/src/screens/WriteReportScreen.js
+++ b/src/screens/WriteReportScreen.js
@@ -1,10 +1,14 @@
+import { yupResolver } from "@hookform/resolvers/yup";
 import { useNavigation, useRoute } from "@react-navigation/native";
 import { useStoreActions } from "easy-peasy";
-import React, { useEffect, useState } from "react";
-import { Text, TextInput, View } from "react-native";
-import { Button, Divider } from "react-native-elements";
+import React, { useEffect, useRef, useState } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { Dimensions, View } from "react-native";
+import { Button } from "react-native-elements";
 
+import TextAreaComponent from "../components/common/TextAreaComponent";
 import HeaderTab from "../components/HeaderTab";
+import { DICTIONARY, SCHEMA } from "../constants";
 import ReportModel from "../models/ReportModel";
 import { goBack } from "../navigations";
 import { showAlertAbsoluteBox, showToastMessage } from "../utilities";
@@ -12,92 +16,82 @@ import store from "../utilities/Store";
 
 store.addModel("ReportModel", ReportModel);
 
+const OFF_SET = 38;
+const CUSTOM_SCREEN_HEIGHT = Dimensions.get("window").height - OFF_SET;
+
 const ReportScreen = () => {
   const route = useRoute();
   const navigation = useNavigation();
-  const [reportParams, setReportParams] = useState({});
-  const [content, setContent] = useState("");
-
+  const reportParam = useRef({});
+  const methods = useForm({
+    mode: "onSubmit",
+    reValidateMode: "onSubmit",
+    resolver: yupResolver(SCHEMA.WRITE_REPORT_FORM),
+  });
+  const { handleSubmit } = methods;
   const [sendStatus, setSendStatus] = useState(null);
   const sendReport = useStoreActions(
     (actions) => actions.ReportModel.sendReport,
   );
 
-  const onSubmit = () => {
-    const trimmedContent = content.trim();
-    // If the content is empty or only contains blank characters
-    if (!trimmedContent) {
-      showToastMessage("Nội dung báo cáo không thể bỏ trống");
-      return;
-    }
-    sendReport({
-      id: reportParams.id,
-      reportDtoIn: trimmedContent,
-      type: reportParams.type,
-      setSendStatus,
-    });
+  const handleGoBack = () => {
+    goBack(navigation);
+  };
+
+  const onSubmit = (data) => {
+    sendReport({ reportDtoIn: data.content, ...reportParam, setSendStatus });
   };
 
   useEffect(() => {
     // If there are params pass through
     if (route.params.id) {
       const { id, type } = route.params;
-      setReportParams({ id, type });
+      reportParam.current = { id, type };
     }
   }, []);
 
   useEffect(() => {
     if (sendStatus === true) {
-      showAlertAbsoluteBox("Trạng thái", "Gửi Thành công", () => {
-        goBack(navigation);
-      });
+      showAlertAbsoluteBox(
+        DICTIONARY.ALERT_TITLE,
+        DICTIONARY.ALERT_CREATE_REPORT_SUCCESS,
+        handleGoBack,
+      );
     }
     if (sendStatus === false) {
-      showToastMessage("Gửi thất bại");
+      showToastMessage(DICTIONARY.TOAST_CREATE_REPORT_FAIL_MSG);
     }
     setSendStatus(null);
   }, [sendStatus]);
 
   return (
-    <View style={{ flex: 1 }}>
-      <HeaderTab name="Báo cáo vi phạm" />
-      <Divider />
-      <View
-        style={{
-          justifyContent: "space-between",
-          flex: 1,
-        }}
-      >
-        <View style={{ marginHorizontal: "10%", marginTop: "5%" }}>
-          <Text
-            style={{
-              fontWeight: "bold",
-              fontSize: 16,
-              marginBottom: 5,
-            }}
-          >
-            Bạn có thể miêu tả rõ được không?
-          </Text>
-          <TextInput
-            multiline
+    <View style={{ height: CUSTOM_SCREEN_HEIGHT }}>
+      <HeaderTab name={DICTIONARY.ANGLER_WRITE_REPORT_HEADER} />
+      <FormProvider {...methods}>
+        <View
+          style={{
+            flex: 1,
+            marginTop: 12,
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          <TextAreaComponent
+            isTitle
+            hasAsterisk
             numberOfLines={6}
-            maxLength={1000}
-            placeholder="Nội dung vi phạm"
-            style={{
-              borderWidth: 0.5,
-              textAlignVertical: "top",
-              padding: 9,
-              backgroundColor: "white",
-            }}
-            onChangeText={setContent}
+            myStyles={{ width: "90%" }}
+            label={DICTIONARY.REPORT_LABEL}
+            placeholder={DICTIONARY.INPUT_REPORT_PLACEHOLDER}
+            controllerName={DICTIONARY.FORM_FIELE_REPORT_CONTENT}
+          />
+          <Button
+            title={DICTIONARY.REPORT_BUTTON_LABEL}
+            containerStyle={{ width: "90%" }}
+            onPress={handleSubmit(onSubmit)}
           />
         </View>
-        <Button
-          containerStyle={{ margin: "10%" }}
-          title="Báo cáo"
-          onPress={onSubmit}
-        />
-      </View>
+      </FormProvider>
     </View>
   );
 };

--- a/src/screens/WriteReviewScreen.js
+++ b/src/screens/WriteReviewScreen.js
@@ -1,7 +1,7 @@
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useNavigation } from "@react-navigation/native";
 import { useStoreActions, useStoreState } from "easy-peasy";
-import React from "react";
+import React, { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { StyleSheet, Text, View } from "react-native";
 import { Avatar, Button, Divider } from "react-native-elements";
@@ -30,7 +30,7 @@ const styles = StyleSheet.create({
 
 const WriteReviewScreen = () => {
   const navigation = useNavigation();
-
+  const [isLoading, setIsLoading] = useState(false);
   const methods = useForm({
     mode: "onSubmit",
     reValidateMode: "onChange",
@@ -47,15 +47,18 @@ const WriteReviewScreen = () => {
   const userInfo = useStoreState((states) => states.ProfileModel.userInfo);
 
   const onSubmit = (data) => {
-    postReview(data).then((result) => {
-      // If api return status of success
-      if (result === 200) {
-        showToastMessage(DICTIONARY.TOAST_WRITE_REVIEW_SUCCESS_MSG);
-        goBack(navigation);
-      } else {
-        showToastMessage(DICTIONARY.ALERT_ERROR_MSG);
-      }
-    });
+    setIsLoading(true);
+    postReview(data)
+      .then((result) => {
+        // If api return status of success
+        if (result === 200) {
+          showToastMessage(DICTIONARY.TOAST_WRITE_REVIEW_SUCCESS_MSG);
+          goBack(navigation);
+        }
+      })
+      .catch(() => {
+        setIsLoading(false);
+      });
   };
 
   return (
@@ -88,6 +91,7 @@ const WriteReviewScreen = () => {
           containerStyle={styles.buttonContainer}
           onPress={handleSubmit(onSubmit)}
           title={DICTIONARY.POST_BUTTON_LABEL}
+          loading={isLoading}
         />
       </FormProvider>
     </View>


### PR DESCRIPTION
Action:
1 - Merge app-toan vào app-duc-final
2 - Sửa label `Số điện thoại mới`
3 - Thêm loading khi đăng bài review tại `WriteReviewScreen` 
4 - Gói `WriteReportScreen` vào hookform và thêm validation và thêm loading
5 - Tạo các label, string của trang `AdminFishEdit` vào `dictionary`
6 - Tạo các label, string của trang `AdminFishingMethodEdit` vào `dictionary`
7 - Dùng `OverlayLoading` vào các trang xem báo cá chi tiết (Trang `VerifyCatchReportDetailScreen` và `AnglerCatchReportDetailScreen`)
8 - Thêm chức năng `onRefresh` cho trang duyệt báo cá, hành vi của onRefresh: chạy khi vào trang lần đầu tiên và khi vuốt xuống => hiện ra con quay ở trên
(* Đã test trường hợp đồng ý => refresh, vào chi tiết đồng ý/từ chối => quay lại => refresh, thoát ra => vào trang => refresh tiếp)
9 - Dùng `ActivityIndicator` loading (xoay tròn giữa màn hình) thay vì dùng `refreshing` loading (style loading mặc định `onRefresh` của `FlatList`) khi màn hình bắt đầu